### PR TITLE
Move rocksdb under feature to reduce compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,6 +1653,7 @@ dependencies = [
  "core-types",
  "cosmwasm-std",
  "data-encoding",
+ "database",
  "derive_more",
  "dircpy",
  "dirs",

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [dependencies]
 thiserror = { workspace = true }
-rocksdb = "0.22.0"
+rocksdb = { version = "0.22.0", optional = true }
 
 [dev-dependencies]
+
+[features]
+rocksdb = ["dep:rocksdb"]

--- a/database/src/error.rs
+++ b/database/src/error.rs
@@ -1,7 +1,13 @@
-use thiserror::Error;
+#[cfg(feature = "rocksdb")]
+pub use self::inner::*;
 
-#[derive(Error, Debug, PartialEq, Eq)]
-pub enum Error {
-    #[error(transparent)]
-    Decode(#[from] rocksdb::Error),
+#[cfg(feature = "rocksdb")]
+mod inner {
+    use thiserror::Error;
+
+    #[derive(Error, Debug, PartialEq, Eq)]
+    pub enum Error {
+        #[error(transparent)]
+        Decode(#[from] rocksdb::Error),
+    }
 }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -4,10 +4,12 @@ pub mod error;
 pub mod ext;
 mod memory;
 mod prefix;
+#[cfg(feature = "rocksdb")]
 mod rocks;
 
 pub use memory::*;
 pub use prefix::*;
+#[cfg(feature = "rocksdb")]
 pub use rocks::*;
 
 pub trait Database {

--- a/gears/Cargo.toml
+++ b/gears/Cargo.toml
@@ -12,6 +12,7 @@ tendermint = { path = "../tendermint" }
 core-types = { path = "../core-types" }
 keyring = { path = "../keyring" }
 store_crate = { path = "../store", package = "store" }
+database = { path = "../database", features = [ "rocksdb" ]}
 
 #newtypes
 # vec1 = "1.12.0"

--- a/gears/src/application/handlers/node.rs
+++ b/gears/src/application/handlers/node.rs
@@ -6,8 +6,9 @@ use crate::{
         tx::{raw::TxWithRaw, TxMessage},
     },
 };
+use database::Database;
 use serde::de::DeserializeOwned;
-use store_crate::{database::Database, StoreKey};
+use store_crate::StoreKey;
 use tendermint::types::{
     proto::validator::ValidatorUpdate,
     request::{begin_block::RequestBeginBlock, end_block::RequestEndBlock, query::RequestQuery},

--- a/gears/src/baseapp/mod.rs
+++ b/gears/src/baseapp/mod.rs
@@ -16,7 +16,8 @@ use crate::{
     },
 };
 use bytes::Bytes;
-use store_crate::{database::RocksDB, types::multi::commit::CommitMultiStore, StoreKey};
+use database::RocksDB;
+use store_crate::{types::multi::commit::CommitMultiStore, StoreKey};
 use tendermint::types::{
     chain_id::ChainIdErrors,
     proto::{event::Event, header::RawHeader},

--- a/gears/src/baseapp/mode/check.rs
+++ b/gears/src/baseapp/mode/check.rs
@@ -1,4 +1,5 @@
-use store_crate::{database::Database, StoreKey};
+use database::Database;
+use store_crate::StoreKey;
 use tendermint::types::proto::event::Event;
 
 use super::ExecutionMode;

--- a/gears/src/baseapp/mode/deliver.rs
+++ b/gears/src/baseapp/mode/deliver.rs
@@ -1,5 +1,6 @@
+use database::Database;
+use store_crate::StoreKey;
 use store_crate::TransactionalMultiKVStore;
-use store_crate::{database::Database, StoreKey};
 use tendermint::types::proto::event::Event;
 
 use crate::types::context::tx::TxContext;

--- a/gears/src/baseapp/mode/mod.rs
+++ b/gears/src/baseapp/mode/mod.rs
@@ -2,7 +2,8 @@ pub mod check;
 pub mod deliver;
 pub mod re_check;
 
-use store_crate::{database::Database, StoreKey};
+use database::Database;
+use store_crate::StoreKey;
 use tendermint::types::proto::event::Event;
 
 use crate::{

--- a/gears/src/baseapp/params.rs
+++ b/gears/src/baseapp/params.rs
@@ -1,6 +1,6 @@
+use database::Database;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use store_crate::database::Database;
 use store_crate::{
     QueryableMultiKVStore, ReadPrefixStore, StoreKey, TransactionalMultiKVStore, WritePrefixStore,
 };

--- a/gears/src/commands/node/run.rs
+++ b/gears/src/commands/node/run.rs
@@ -7,9 +7,9 @@ use crate::params::{Keeper, ParamsSubspaceKey};
 use crate::rest::{run_rest_server, RestState};
 use crate::types::tx::TxMessage;
 use axum::Router;
+use database::RocksDB;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use store_crate::database::RocksDB;
 use store_crate::StoreKey;
 use tendermint::abci::ServerBuilder;
 use tendermint::application::ABCI;
@@ -30,7 +30,7 @@ pub enum RunError {
     #[error("{0}")]
     HomeDirectory(String),
     #[error("{0}")]
-    Database(#[from] store_crate::database::error::Error),
+    Database(#[from] database::error::Error),
     #[error("{0}")]
     TendermintServer(#[from] tendermint::abci::errors::Error),
     #[error("{0}")]

--- a/gears/src/lib.rs
+++ b/gears/src/lib.rs
@@ -30,4 +30,7 @@ pub mod tendermint {
 #[cfg(feature = "export")]
 pub mod store {
     pub use store_crate::*;
+    pub mod database {
+        pub use database::*;
+    }
 }

--- a/gears/src/params.rs
+++ b/gears/src/params.rs
@@ -1,5 +1,5 @@
+use database::{Database, PrefixDB};
 use std::{hash::Hash, marker::PhantomData};
-use store_crate::database::{Database, PrefixDB};
 use store_crate::{
     types::prefix::{immutable::ImmutablePrefixStore, mutable::MutablePrefixStore},
     QueryableKVStore, StoreKey, TransactionalKVStore,

--- a/gears/src/types/context/init.rs
+++ b/gears/src/types/context/init.rs
@@ -1,4 +1,4 @@
-use store_crate::database::{Database, PrefixDB};
+use database::{Database, PrefixDB};
 use store_crate::types::kv::mutable::KVStoreMut;
 use store_crate::types::multi::commit::CommitMultiStore;
 use store_crate::types::multi::mutable::MultiStoreMut;

--- a/gears/src/types/context/mod.rs
+++ b/gears/src/types/context/mod.rs
@@ -1,4 +1,4 @@
-use store_crate::database::{Database, PrefixDB};
+use database::{Database, PrefixDB};
 use store_crate::types::kv::mutable::KVStoreMut;
 use store_crate::types::kv::KVStore;
 use store_crate::types::multi::mutable::MultiStoreMut;

--- a/gears/src/types/context/query.rs
+++ b/gears/src/types/context/query.rs
@@ -1,4 +1,4 @@
-use store_crate::database::{Database, PrefixDB};
+use database::{Database, PrefixDB};
 use store_crate::types::kv::KVStore;
 use store_crate::types::multi::commit::CommitMultiStore;
 use store_crate::QueryableMultiKVStore;

--- a/gears/src/types/context/tx.rs
+++ b/gears/src/types/context/tx.rs
@@ -1,5 +1,5 @@
+use database::{Database, PrefixDB};
 use store_crate::{
-    database::{Database, PrefixDB},
     types::{
         kv::{mutable::KVStoreMut, KVStore},
         multi::{commit::CommitMultiStore, mutable::MultiStoreMut, MultiStore},

--- a/gears/src/types/decimal256.rs
+++ b/gears/src/types/decimal256.rs
@@ -5,6 +5,7 @@ use cosmwasm_std::StdError;
 
 /// Trait for converting to and from a string which is compatible with the cosmos SDK protobufs.
 /// The cosmos SDK uses a string representation of the inner `Uint256` to represent a `Decimal256`.
+#[allow(dead_code)] // TODO: After merge of Dmytro PR with usage of this trait
 trait CosmosDecimalProtoString: Sized {
     /// Converts to a string which is compatible with the cosmos SDK protobufs.
     fn to_cosmos_proto_string(&self) -> String;

--- a/gears/src/x/ante.rs
+++ b/gears/src/x/ante.rs
@@ -26,9 +26,9 @@ use core_types::{
     signing::SignDoc,
     tx::mode_info::{ModeInfo, SignMode},
 };
+use database::Database;
 use prost::Message as ProstMessage;
 use std::marker::PhantomData;
-use store_crate::database::Database;
 use store_crate::StoreKey;
 
 pub trait SignGasConsumer: Clone + Sync + Send + 'static {

--- a/gears/src/x/keepers/auth.rs
+++ b/gears/src/x/keepers/auth.rs
@@ -1,5 +1,6 @@
 use core_types::address::AccAddress;
-use store_crate::{database::Database, StoreKey};
+use database::Database;
+use store_crate::StoreKey;
 
 use crate::{
     types::{

--- a/gears/src/x/keepers/bank.rs
+++ b/gears/src/x/keepers/bank.rs
@@ -1,5 +1,6 @@
 use core_types::address::AccAddress;
-use store_crate::{database::Database, StoreKey};
+use database::Database;
+use store_crate::StoreKey;
 
 use crate::{
     error::AppError,

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(rust_2018_idioms)]
-
 use ::database::PrefixDB;
 use range::Range;
 use strum::IntoEnumIterator;
@@ -13,10 +11,6 @@ mod hash;
 pub mod range;
 pub mod types;
 mod utils;
-
-pub mod database {
-    pub use database::*;
-}
 
 use std::{hash::Hash, ops::RangeBounds};
 


### PR DESCRIPTION
I mainly turn off all crates except I'm working on, but librocksdb still needs to be recompiled, so I put it under feature to reduce compilation time in cases where I don't need it.