### PR TITLE
Use u32 for block heights

### DIFF
--- a/gears/src/baseapp/abci.rs
+++ b/gears/src/baseapp/abci.rs
@@ -81,10 +81,7 @@ impl<DB: Database, PSK: ParamsSubspaceKey, H: ABCIHandler, AI: ApplicationInfo>
             data: AI::APP_NAME.to_owned(),
             version: AI::APP_VERSION.to_owned(),
             app_version: 1,
-            last_block_height: self
-                .block_height()
-                .try_into()
-                .expect("can't believe we made it this far"),
+            last_block_height: self.block_height(),
             last_block_app_hash: self.get_last_commit_hash().to_vec().into(),
         }
     }
@@ -101,10 +98,7 @@ impl<DB: Database, PSK: ParamsSubspaceKey, H: ABCIHandler, AI: ApplicationInfo>
                 key: request.data,
                 value: res,
                 proof_ops: None,
-                height: self
-                    .block_height()
-                    .try_into()
-                    .expect("can't believe we made it this far"),
+                height: self.block_height(),
                 codespace: "".to_string(),
             },
             Err(e) => ResponseQuery {
@@ -226,9 +220,7 @@ impl<DB: Database, PSK: ParamsSubspaceKey, H: ABCIHandler, AI: ApplicationInfo>
 
         ResponseCommit {
             data: hash.to_vec().into(),
-            retain_height: (height - 1)
-                .try_into()
-                .expect("can't believe we made it this far"),
+            retain_height: (height - 1), // TODO: check if this is correct - why -1?
         }
     }
 

--- a/gears/src/baseapp/mode/check.rs
+++ b/gears/src/baseapp/mode/check.rs
@@ -44,7 +44,7 @@ impl<DB: Database, AH: ABCIHandler> ExecutionMode<DB, AH> for CheckTxMode<DB, AH
 
     fn build_ctx(
         &mut self,
-        height: u64,
+        height: u32,
         header: Header,
         consensus_params: ConsensusParams,
         fee: Option<&Fee>,

--- a/gears/src/baseapp/mode/deliver.rs
+++ b/gears/src/baseapp/mode/deliver.rs
@@ -47,7 +47,7 @@ impl<DB: Database + Sync + Send, AH: ABCIHandler> ExecutionMode<DB, AH> for Deli
 
     fn build_ctx(
         &mut self,
-        height: u64,
+        height: u32,
         header: Header,
         consensus_params: ConsensusParams,
         fee: Option<&Fee>,

--- a/gears/src/baseapp/mode/mod.rs
+++ b/gears/src/baseapp/mode/mod.rs
@@ -27,7 +27,7 @@ pub trait ExecutionMode<DB, AH: ABCIHandler>: Sealed {
 
     fn build_ctx(
         &mut self,
-        height: u64,
+        height: u32,
         header: Header,
         consensus_params: ConsensusParams,
         fee: Option<&Fee>,
@@ -66,7 +66,7 @@ mod sealed {
     impl<DB, AH: ABCIHandler> Sealed for DeliverTxMode<DB, AH> {}
 }
 
-fn build_tx_gas_meter(block_height: u64, fee: Option<&Fee>) -> GasMeter<TxKind> {
+fn build_tx_gas_meter(block_height: u32, fee: Option<&Fee>) -> GasMeter<TxKind> {
     if block_height == 0 {
         GasMeter::new(Box::<InfiniteGasMeter>::default())
     } else {

--- a/gears/src/context/block.rs
+++ b/gears/src/context/block.rs
@@ -19,7 +19,7 @@ use super::{InfallibleContext, InfallibleContextMut, QueryableContext, Transacti
 #[derive(Debug)]
 pub struct BlockContext<'a, DB, SK> {
     multi_store: &'a mut MultiBank<DB, SK, ApplicationStore>,
-    pub(crate) height: u64,
+    pub(crate) height: u32,
     pub header: Header,
     pub events: Vec<Event>,
 }
@@ -27,7 +27,7 @@ pub struct BlockContext<'a, DB, SK> {
 impl<'a, DB, SK> BlockContext<'a, DB, SK> {
     pub fn new(
         multi_store: &'a mut MultiBank<DB, SK, ApplicationStore>,
-        height: u64,
+        height: u32,
         header: Header,
     ) -> Self {
         BlockContext {
@@ -54,7 +54,7 @@ impl<DB: Database, SK: StoreKey> BlockContext<'_, DB, SK> {
 }
 
 impl<DB: Database, SK: StoreKey> QueryableContext<DB, SK> for BlockContext<'_, DB, SK> {
-    fn height(&self) -> u64 {
+    fn height(&self) -> u32 {
         self.height
     }
 

--- a/gears/src/context/init.rs
+++ b/gears/src/context/init.rs
@@ -13,7 +13,7 @@ use super::{InfallibleContext, InfallibleContextMut, QueryableContext, Transacti
 #[derive(Debug)]
 pub struct InitContext<'a, DB, SK> {
     multi_store: &'a mut MultiBank<DB, SK, ApplicationStore>,
-    pub(crate) height: u64,
+    pub(crate) height: u32,
     pub(crate) time: Timestamp,
     pub events: Vec<Event>,
     pub(crate) chain_id: ChainId,
@@ -22,7 +22,7 @@ pub struct InitContext<'a, DB, SK> {
 impl<'a, DB, SK> InitContext<'a, DB, SK> {
     pub fn new(
         multi_store: &'a mut MultiBank<DB, SK, ApplicationStore>,
-        height: u64,
+        height: u32,
         time: Timestamp,
         chain_id: ChainId,
     ) -> Self {
@@ -51,7 +51,7 @@ impl<'a, DB: Database, SK: StoreKey> InitContext<'a, DB, SK> {
 }
 
 impl<DB: Database, SK: StoreKey> QueryableContext<DB, SK> for InitContext<'_, DB, SK> {
-    fn height(&self) -> u64 {
+    fn height(&self) -> u32 {
         self.height
     }
 

--- a/gears/src/context/mod.rs
+++ b/gears/src/context/mod.rs
@@ -14,7 +14,7 @@ pub trait QueryableContext<DB, SK> {
     /// Fetches an immutable ref to a KVStore from the MultiStore.
     fn kv_store(&self, store_key: &SK) -> Store<'_, PrefixDB<DB>>;
 
-    fn height(&self) -> u64;
+    fn height(&self) -> u32;
     // fn chain_id(&self) -> &ChainId;
 }
 

--- a/gears/src/context/query.rs
+++ b/gears/src/context/query.rs
@@ -12,7 +12,7 @@ use super::{InfallibleContext, QueryableContext};
 
 pub struct QueryContext<DB, SK> {
     multi_store: QueryMultiStore<DB, SK>,
-    pub(crate) height: u64,
+    pub(crate) height: u32,
     pub(crate) chain_id: ChainId,
 }
 
@@ -24,7 +24,7 @@ impl<DB: Database, SK: StoreKey> QueryContext<DB, SK> {
     ) -> Result<Self, KVStoreError> {
         Ok(QueryContext {
             multi_store,
-            height: version as u64, // TODO:
+            height: version,
             chain_id: ChainId::new("todo-900").expect("default should be valid"),
         })
     }
@@ -41,7 +41,7 @@ impl<DB: Database, SK: StoreKey> QueryContext<DB, SK> {
 }
 
 impl<DB: Database, SK: StoreKey> QueryableContext<DB, SK> for QueryContext<DB, SK> {
-    fn height(&self) -> u64 {
+    fn height(&self) -> u32 {
         self.height
     }
 

--- a/gears/src/context/simple.rs
+++ b/gears/src/context/simple.rs
@@ -29,11 +29,11 @@ impl<'a, DB, SK> From<&'a mut MultiBank<DB, SK, TransactionStore>> for SimpleBac
 #[derive(Debug)]
 pub struct SimpleContext<'a, DB, SK> {
     multi_store: SimpleBackend<'a, DB, SK>,
-    height: u64,
+    height: u32,
 }
 
 impl<'a, DB, SK> SimpleContext<'a, DB, SK> {
-    pub fn new(multi_store: SimpleBackend<'a, DB, SK>, height: u64) -> Self {
+    pub fn new(multi_store: SimpleBackend<'a, DB, SK>, height: u32) -> Self {
         Self {
             multi_store,
             height,
@@ -44,7 +44,7 @@ impl<'a, DB, SK> SimpleContext<'a, DB, SK> {
 impl<'a, DB, SK> SimpleContext<'a, DB, SK> {}
 
 impl<DB: Database, SK: StoreKey> QueryableContext<DB, SK> for SimpleContext<'_, DB, SK> {
-    fn height(&self) -> u64 {
+    fn height(&self) -> u32 {
         self.height
     }
 

--- a/gears/src/context/tx.rs
+++ b/gears/src/context/tx.rs
@@ -38,7 +38,7 @@ pub struct TxContext<'a, DB, SK> {
     pub gas_meter: Arc<RefCell<GasMeter<TxKind>>>,
     pub events: Vec<Event>,
     pub options: NodeOptions,
-    pub(crate) height: u64,
+    pub(crate) height: u32,
     pub(crate) header: Header,
     pub(crate) block_gas_meter: &'a mut GasMeter<BlockKind>,
     pub(crate) consensus_params: ConsensusParams,
@@ -49,7 +49,7 @@ pub struct TxContext<'a, DB, SK> {
 impl<'a, DB, SK> TxContext<'a, DB, SK> {
     pub fn new(
         multi_store: &'a mut MultiBank<DB, SK, TransactionStore>,
-        height: u64,
+        height: u32,
         header: Header,
         consensus_params: ConsensusParams,
         gas_meter: GasMeter<TxKind>,
@@ -114,7 +114,7 @@ impl<DB: Database, SK: StoreKey> TxContext<'_, DB, SK> {
 }
 
 impl<DB: Database, SK: StoreKey> QueryableContext<DB, SK> for TxContext<'_, DB, SK> {
-    fn height(&self) -> u64 {
+    fn height(&self) -> u32 {
         self.height
     }
 

--- a/gears/src/error.rs
+++ b/gears/src/error.rs
@@ -16,7 +16,7 @@ pub enum AppError {
     TxParseError(String),
     Coins(String),
     TxValidation(String),
-    Timeout { timeout: u64, current: u64 },
+    Timeout { timeout: u32, current: u32 },
     Memo(u64),
     InvalidPublicKey,
     Store(KVStoreError),

--- a/gears/src/signing/renderer/primitives/mod.rs
+++ b/gears/src/signing/renderer/primitives/mod.rs
@@ -9,5 +9,6 @@ pub mod decimal256;
 pub mod i64;
 pub mod send_coins;
 pub mod string;
+pub mod u32;
 pub mod u64;
 pub mod uint256;

--- a/gears/src/signing/renderer/primitives/u32.rs
+++ b/gears/src/signing/renderer/primitives/u32.rs
@@ -1,0 +1,47 @@
+//! Default formatting implementation for `u32`
+
+use crate::signing::renderer::value_renderer::{DefaultPrimitiveRenderer, PrimitiveValueRenderer};
+use crate::types::rendering::screen::Content;
+use num_format::Buffer;
+
+use super::i64::format_get;
+
+impl PrimitiveValueRenderer<u32> for DefaultPrimitiveRenderer {
+    fn format(value: u32) -> Content {
+        let mut buf = Buffer::new();
+        buf.write_formatted(&value, format_get());
+
+        Content::new(buf.to_string()).expect("String will never be empty")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::signing::renderer::value_renderer::{
+        DefaultPrimitiveRenderer, PrimitiveValueRenderer,
+    };
+
+    #[test]
+    fn test_positive() {
+        let test_data = [
+            (1_u32, "1"),
+            (2, "2"),
+            (10, "10"),
+            (30, "30"),
+            (100, "100"),
+            (500, "500"),
+            (1000, "1'000"),
+            (5000, "5'000"),
+            (10_000, "10'000"),
+            (100_000, "100'000"),
+            (5_000_000, "5'000'000"),
+            (50_000_000, "50'000'000"),
+        ];
+
+        for (i, expected) in test_data {
+            let actual = DefaultPrimitiveRenderer::format(i);
+
+            assert_eq!(expected, &actual.into_inner());
+        }
+    }
+}

--- a/gears/src/signing/renderer/tx/tx.rs
+++ b/gears/src/signing/renderer/tx/tx.rs
@@ -36,7 +36,7 @@ pub struct Envelope<M> {
     tip: Option<SendCoins>,
     tipper: Option<AccAddress>,
     gas_limit: u64,
-    timeout_height: u64,
+    timeout_height: u32,
     // TODO: need to add the fields below in:
     //other_signer: Vec<SignerInfo>,
     //extension_options: Vec<>,

--- a/gears/src/types/tx/mod.rs
+++ b/gears/src/types/tx/mod.rs
@@ -90,7 +90,7 @@ impl<M: TxMessage> Tx<M> {
         &self.signatures_data
     }
 
-    pub fn get_timeout_height(&self) -> u64 {
+    pub fn get_timeout_height(&self) -> u32 {
         self.body.timeout_height
     }
 

--- a/kv_store/src/types/multi/commit.rs
+++ b/kv_store/src/types/multi/commit.rs
@@ -66,7 +66,7 @@ impl<DB: Database, SK: StoreKey> MultiBank<DB, SK, ApplicationStore> {
         let hash = crate::hash::hash_store_infos(store_infos);
 
         self.head_commit_hash = hash;
-        self.head_version += 1;
+        self.head_version += 1; //TODO: wraps on overflow - should halt the chain (panic)
         hash
     }
 

--- a/tendermint/src/application.rs
+++ b/tendermint/src/application.rs
@@ -47,9 +47,7 @@ pub trait ABCIApplication<G>: Send + Clone + 'static {
     }
 
     /// Provide information about the ABCI application.
-    fn info(&self, _request: RequestInfo) -> ResponseInfo {
-        Default::default()
-    }
+    fn info(&self, _request: RequestInfo) -> ResponseInfo;
 
     /// Called once upon genesis.
     fn init_chain(&self, _request: RequestInitChain<G>) -> ResponseInitChain {
@@ -57,9 +55,7 @@ pub trait ABCIApplication<G>: Send + Clone + 'static {
     }
 
     /// Query the application for data at the current or past height.
-    fn query(&self, _request: RequestQuery) -> ResponseQuery {
-        Default::default()
-    }
+    fn query(&self, _request: RequestQuery) -> ResponseQuery;
 
     /// Check the given transaction before putting it into the local mempool.
     fn check_tx(&self, _request: RequestCheckTx) -> ResponseCheckTx {
@@ -87,9 +83,7 @@ pub trait ABCIApplication<G>: Send + Clone + 'static {
     }
 
     /// Commit the current state at the current height.
-    fn commit(&self) -> ResponseCommit {
-        Default::default()
-    }
+    fn commit(&self) -> ResponseCommit;
 
     /// Used during state sync to discover available snapshots on peers.
     fn list_snapshots(&self) -> ResponseListSnapshots {

--- a/tendermint/src/types/response/info.rs
+++ b/tendermint/src/types/response/info.rs
@@ -1,18 +1,13 @@
-#[derive(Clone, PartialEq, Eq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ResponseInfo {
-    #[prost(string, tag = "1")]
     #[serde(default)]
-    pub data: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
+    pub data: String,
     #[serde(default)]
-    pub version: ::prost::alloc::string::String,
-    #[prost(uint64, tag = "3")]
+    pub version: String,
     #[serde(with = "crate::types::serializers::from_str", default)]
     pub app_version: u64,
-    #[prost(int64, tag = "4")]
     #[serde(with = "crate::types::serializers::from_str", default)]
-    pub last_block_height: i64,
-    #[prost(bytes = "bytes", tag = "5")]
+    pub last_block_height: u32,
     #[serde(default)]
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     pub last_block_app_hash: ::prost::bytes::Bytes,
@@ -32,27 +27,7 @@ impl From<ResponseInfo> for super::inner::ResponseInfo {
             data,
             version,
             app_version,
-            last_block_height,
-            last_block_app_hash,
-        }
-    }
-}
-
-impl From<super::inner::ResponseInfo> for ResponseInfo {
-    fn from(
-        super::inner::ResponseInfo {
-            data,
-            version,
-            app_version,
-            last_block_height,
-            last_block_app_hash,
-        }: super::inner::ResponseInfo,
-    ) -> Self {
-        Self {
-            data,
-            version,
-            app_version,
-            last_block_height,
+            last_block_height: last_block_height.into(),
             last_block_app_hash,
         }
     }

--- a/tendermint/src/types/response/mod.rs
+++ b/tendermint/src/types/response/mod.rs
@@ -39,27 +39,11 @@ impl From<ResponseFlush> for inner::ResponseFlush {
         Self {}
     }
 }
-#[derive(Clone, PartialEq, Eq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ResponseCommit {
     /// reserve 1
-    #[prost(bytes = "bytes", tag = "2")]
     pub data: ::prost::bytes::Bytes,
-    #[prost(int64, tag = "3")]
-    pub retain_height: i64,
-}
-
-impl From<inner::ResponseCommit> for ResponseCommit {
-    fn from(
-        inner::ResponseCommit {
-            data,
-            retain_height,
-        }: inner::ResponseCommit,
-    ) -> Self {
-        Self {
-            data,
-            retain_height,
-        }
-    }
+    pub retain_height: u32,
 }
 
 impl From<ResponseCommit> for inner::ResponseCommit {
@@ -71,7 +55,7 @@ impl From<ResponseCommit> for inner::ResponseCommit {
     ) -> Self {
         Self {
             data,
-            retain_height,
+            retain_height: retain_height.into(),
         }
     }
 }

--- a/tendermint/src/types/response/query.rs
+++ b/tendermint/src/types/response/query.rs
@@ -1,57 +1,22 @@
+use bytes::Bytes;
+
 use crate::types::proto::crypto::ProofOps;
 
-#[derive(Clone, PartialEq, Eq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ResponseQuery {
-    #[prost(uint32, tag = "1")]
     pub code: u32,
     /// bytes data = 2; // use "value" instead.
     ///
     /// nondeterministic
-    #[prost(string, tag = "3")]
     pub log: String,
     /// nondeterministic
-    #[prost(string, tag = "4")]
     pub info: String,
-    #[prost(int64, tag = "5")]
     pub index: i64,
-    #[prost(bytes = "bytes", tag = "6")]
-    pub key: ::prost::bytes::Bytes,
-    #[prost(bytes = "bytes", tag = "7")]
-    pub value: ::prost::bytes::Bytes,
-    #[prost(message, optional, tag = "8")]
+    pub key: Bytes,
+    pub value: Bytes,
     pub proof_ops: Option<ProofOps>,
-    #[prost(int64, tag = "9")]
-    pub height: i64,
-    #[prost(string, tag = "10")]
+    pub height: u32,
     pub codespace: String,
-}
-
-impl From<super::inner::ResponseQuery> for ResponseQuery {
-    fn from(
-        super::inner::ResponseQuery {
-            code,
-            log,
-            info,
-            index,
-            key,
-            value,
-            proof_ops,
-            height,
-            codespace,
-        }: super::inner::ResponseQuery,
-    ) -> Self {
-        Self {
-            code,
-            log,
-            info,
-            index,
-            key,
-            value,
-            proof_ops: proof_ops.map(Into::into),
-            height,
-            codespace,
-        }
-    }
 }
 
 impl From<ResponseQuery> for super::inner::ResponseQuery {
@@ -76,7 +41,7 @@ impl From<ResponseQuery> for super::inner::ResponseQuery {
             key,
             value,
             proof_ops: proof_ops.map(Into::into),
-            height,
+            height: height.into(),
             codespace,
         }
     }

--- a/x/ibc-rs/src/types/context/context.rs
+++ b/x/ibc-rs/src/types/context/context.rs
@@ -676,7 +676,7 @@ impl<'a, 'b, DB: Database, SK: StoreKey, PSK: ParamsSubspaceKey> ExtClientValida
     ) -> Result<ibc::core::client::types::Height, ibc::core::handler::types::error::ContextError>
     {
         // TODO: check impl
-        Ok(Height::new(0, self.gears_ctx.height()).unwrap()) //TODO: unwrap
+        Ok(Height::new(0, self.gears_ctx.height().into()).unwrap()) //TODO: unwrap
     }
 
     fn consensus_state_heights(

--- a/x/staking/src/keeper/historical_info.rs
+++ b/x/staking/src/keeper/historical_info.rs
@@ -22,9 +22,9 @@ impl<
         // over the historical entries starting from the most recent version to be pruned
         // and then return at the first empty entry.
 
-        if ctx.height() >= entry_num as u64 {
+        if ctx.height() >= entry_num {
             // if (ctx.height() as i64 - entry_num as i64) >= 0 {
-            for i in (0..=(ctx.height() - entry_num as u64)).rev() {
+            for i in (0..=(ctx.height() - entry_num)).rev() {
                 if let Some(_info) = self.historical_info(ctx, i).unwrap_gas() {
                     self.delete_historical_info(ctx, i).unwrap();
                 } else {
@@ -55,7 +55,7 @@ impl<
     pub fn historical_info<DB: Database, CTX: QueryableContext<DB, SK>>(
         &self,
         ctx: &CTX,
-        height: u64,
+        height: u32,
     ) -> Result<Option<HistoricalInfo>, GasStoreErrors> {
         let store = ctx.kv_store(&self.store_key);
         let store = store.prefix_store(HISTORICAL_INFO_KEY);
@@ -69,7 +69,7 @@ impl<
     pub fn delete_historical_info<DB: Database, CTX: TransactionalContext<DB, SK>>(
         &self,
         ctx: &mut CTX,
-        height: u64,
+        height: u32,
     ) -> Result<Option<Vec<u8>>, GasStoreErrors> {
         let store = ctx.kv_store_mut(&self.store_key);
         let mut store = store.prefix_store_mut(HISTORICAL_INFO_KEY);
@@ -81,7 +81,7 @@ impl<
     pub fn set_historical_info<DB: Database, CTX: TransactionalContext<DB, SK>>(
         &self,
         ctx: &mut CTX,
-        height: u64,
+        height: u32,
         info: &HistoricalInfo,
     ) -> Result<(), GasStoreErrors> {
         let store = ctx.kv_store_mut(&self.store_key);

--- a/x/staking/src/keeper/mod.rs
+++ b/x/staking/src/keeper/mod.rs
@@ -576,7 +576,7 @@ impl<
                 let time =
                     chrono::DateTime::from_timestamp(time.seconds, time.nanos as u32).unwrap();
                 let completion_time = time + duration;
-                let height = ctx.height();
+                let height = ctx.height() as u64;
                 // TODO: consider to work with time in Gears
                 let completion_time = Timestamp {
                     seconds: completion_time.timestamp(),

--- a/x/staking/src/keeper/unbonding.rs
+++ b/x/staking/src/keeper/unbonding.rs
@@ -210,7 +210,7 @@ impl<
         let block_time =
             chrono::DateTime::from_timestamp(block_time.seconds, block_time.nanos as u32).unwrap();
 
-        let block_height = ctx.height();
+        let block_height = ctx.height() as u64;
 
         // unbondingValIterator will contains all validator addresses indexed under
         // the ValidatorQueueKey prefix. Note, the entire index key is composed as
@@ -374,7 +374,7 @@ impl<
 
         // set the unbonding completion time and completion height appropriately
         validator.unbonding_time = ctx.get_time();
-        validator.unbonding_height = ctx.height();
+        validator.unbonding_height = ctx.height() as u64;
 
         // save the now unbonded validator record and power index
         self.set_validator(ctx, validator)?;

--- a/x/staking/src/keys.rs
+++ b/x/staking/src/keys.rs
@@ -27,7 +27,7 @@ pub fn length_prefixed_val_del_addrs_key(
     prefix
 }
 
-pub fn historical_info_key(height: u64) -> Vec<u8> {
+pub fn historical_info_key(height: u32) -> Vec<u8> {
     let mut res = Vec::with_capacity(9);
     res.extend_from_slice(&HISTORICAL_INFO_KEY);
     res.extend_from_slice(&height.to_le_bytes());


### PR DESCRIPTION
Since Tendermint uses i64 to represent heights the only sensible option is to use a u32 in gears.