### PR TITLE
Validate genesis data during parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4847,6 +4847,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
   "x/auth",
   "x/bank",
   "x/ibc-rs",
-  "x/staking", 
+  "x/staking",
   "x/gov",
 
   # new unsorted

--- a/x/staking/Cargo.toml
+++ b/x/staking/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 anyhow = { workspace = true }
 axum = { workspace = true }
 bank = { path = "../bank/" }
-chrono = { version = "0.4.38", features = [ "serde" ] }
+chrono = { version = "0.4.38", features = ["serde"] }
 clap = { workspace = true }
-gears = { path = "../../gears", features = [ "cli", "export", "xmods" ] }
+gears = { path = "../../gears", features = ["cli", "export", "xmods"] }
 prost = { workspace = true }
 strum = { workspace = true }
 serde = { workspace = true, default-features = false }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+thiserror = { workspace = true }

--- a/x/staking/src/abci_handler.rs
+++ b/x/staking/src/abci_handler.rs
@@ -75,10 +75,6 @@ impl<
     }
 
     pub fn genesis<DB: Database>(&self, ctx: &mut InitContext<'_, DB, SK>, genesis: GenesisState) {
-        // TODO: should it be a part of gears genesis handler?
-        if let Err(e) = genesis.validate() {
-            panic!("Something went wrong with staking genesis state.\n{}", e);
-        }
         self.keeper.init_genesis(ctx, genesis);
     }
 
@@ -110,8 +106,7 @@ impl<
                     .encode_vec()
                     .into())
             }
-            "/cosmos/staking/v1beta1/params" |
-            "/cosmos.staking.v1beta1.Query/Params" => {
+            "/cosmos/staking/v1beta1/params" | "/cosmos.staking.v1beta1.Query/Params" => {
                 Ok(self.keeper.query_params(ctx).encode_vec().into())
             }
             _ => Err(AppError::InvalidRequest("query path not found".into())),

--- a/x/staking/src/genesis.rs
+++ b/x/staking/src/genesis.rs
@@ -1,18 +1,15 @@
-use crate::{Delegation, LastValidatorPower, Params, Redelegation, UnbondingDelegation, Validator};
-use gears::{
-    error::AppError,
-    types::{address::ConsAddress, uint::Uint256},
-    x::types::validator::BondStatus,
+use crate::{
+    Delegation, LastValidatorPower, Params, Redelegation, UnbondingDelegation, Validators,
 };
+use gears::types::uint::Uint256;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct GenesisState {
     /// params defines all the parameters of related to deposit.
     pub params: Params,
     /// validators defines the validator set at genesis.
-    pub validators: Vec<Validator>,
+    pub validators: Validators,
     pub last_total_power: Uint256,
     pub exported: bool,
     pub last_validator_powers: Vec<LastValidatorPower>,
@@ -21,43 +18,171 @@ pub struct GenesisState {
     pub redelegations: Vec<Redelegation>,
 }
 
-impl GenesisState {
-    /// Validates the provided staking genesis state to ensure the
-    /// expected invariants holds. (i.e. params in correct bounds, no duplicate validators)
-    pub fn validate(&self) -> Result<(), AppError> {
-        self.validate_validators()?;
-        self.params.validate()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_genesis() {
+        let genesis = r#"{
+            "params": {
+                "unbonding_time": 1814400,
+                "max_validators": 100,
+                "max_entries": 7,
+                "historical_entries": 10000,
+                "bond_denom": "stake"
+            },
+            "validators": [
+                {
+    "operator_address": "cosmosvaloper1sp6zygg2wch",
+    "delegator_shares": "1",
+    "description": {
+        "moniker": "validator1",
+        "identity": "",
+        "website": "",
+        "security_contact": "",
+        "details": ""
+    },
+    "consensus_pubkey": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "cVp6"
+    },
+    "jailed": false,
+    "tokens": "1",
+    "unbonding_height": 0,
+    "unbonding_time": "1970-01-01T00:00:10.0000001Z",
+    "commission": {
+        "commission_rates": {
+            "rate": "1",
+            "max_rate": "1",
+            "max_change_rate": "1"
+        },
+        "update_time": "1970-01-01T00:00:10.0000001Z"
+    },
+    "min_self_delegation": "1",
+    "status": "Bonded"
+}
+            ],
+            "last_total_power": "0",
+            "exported": false,
+            "last_validator_powers": [],
+            "delegations": [],
+            "unbonding_delegations": [],
+            "redelegations": []
+        }"#;
+
+        assert!(serde_json::from_str::<GenesisState>(genesis).is_ok());
     }
 
-    fn validate_validators(&self) -> Result<(), AppError> {
-        let mut addr_set: HashSet<&[u8]> = HashSet::new();
-        for v in self.validators.iter() {
-            let cons_pub_key_raw = v.consensus_pubkey.raw();
-            if addr_set.contains(cons_pub_key_raw) {
-                let str_pub_addr: ConsAddress = v.consensus_pubkey.clone().into();
-                return Err(AppError::Custom(format!(
-                    "duplicate validator in genesis state: moniker {}, address {}",
-                    v.description.moniker, str_pub_addr
-                )));
-            }
+    #[test]
+    /// Fails because validator is jailed and bonded
+    fn test_deserialize_genesis_fail() {
+        let genesis = r#"{
+            "params": {
+                "unbonding_time": 1814400,
+                "max_validators": 100,
+                "max_entries": 7,
+                "historical_entries": 10000,
+                "bond_denom": "stake"
+            },
+            "validators": [
+                {
+    "operator_address": "cosmosvaloper1sp6zygg2wch",
+    "delegator_shares": "1",
+    "description": {
+        "moniker": "validator1",
+        "identity": "",
+        "website": "",
+        "security_contact": "",
+        "details": ""
+    },
+    "consensus_pubkey": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "cVp6"
+    },
+    "jailed": true,
+    "tokens": "1",
+    "unbonding_height": 0,
+    "unbonding_time": "1970-01-01T00:00:10.0000001Z",
+    "commission": {
+        "commission_rates": {
+            "rate": "1",
+            "max_rate": "1",
+            "max_change_rate": "1"
+        },
+        "update_time": "1970-01-01T00:00:10.0000001Z"
+    },
+    "min_self_delegation": "1",
+    "status": "Bonded"
+}
+            ],
+            "last_total_power": "0",
+            "exported": false,
+            "last_validator_powers": [],
+            "delegations": [],
+            "unbonding_delegations": [],
+            "redelegations": []
+        }"#;
 
-            if v.jailed && v.status == BondStatus::Bonded {
-                let str_pub_addr: ConsAddress = v.consensus_pubkey.clone().into();
-                return Err(AppError::Custom(format!(
-                    "validator is bonded and jailed in genesis state: moniker {}, address {}",
-                    v.description.moniker, str_pub_addr
-                )));
-            }
+        assert_eq!(serde_json::from_str::<GenesisState>(genesis).unwrap_err().to_string(),
+        "validator is bonded and jailed in genesis state: moniker validator1, address cosmosvalcons1skvfj3jt9npmce99zrvp9s59z54kx7vzw7p6lh at line 39 column 13".to_string());
+    }
 
-            if v.delegator_shares.is_zero() && v.status != BondStatus::Unbonding {
-                return Err(AppError::Custom(format!(
-                    "bonded/unbonded genesis validator cannot have zero delegator shares, validator: {}",
-                    v.operator_address
-                )));
-            }
+    #[test]
+    /// Fails because params are invalid
+    fn test_deserialize_genesis_fail_invalid_params() {
+        let genesis = r#"{
+            "params": {
+                "unbonding_time": -1,
+                "max_validators": 100,
+                "max_entries": 7,
+                "historical_entries": 10000,
+                "bond_denom": "stake"
+            },
+            "validators": [
+                {
+    "operator_address": "cosmosvaloper1sp6zygg2wch",
+    "delegator_shares": "1",
+    "description": {
+        "moniker": "validator1",
+        "identity": "",
+        "website": "",
+        "security_contact": "",
+        "details": ""
+    },
+    "consensus_pubkey": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "cVp6"
+    },
+    "jailed": true,
+    "tokens": "1",
+    "unbonding_height": 0,
+    "unbonding_time": "1970-01-01T00:00:10.0000001Z",
+    "commission": {
+        "commission_rates": {
+            "rate": "1",
+            "max_rate": "1",
+            "max_change_rate": "1"
+        },
+        "update_time": "1970-01-01T00:00:10.0000001Z"
+    },
+    "min_self_delegation": "1",
+    "status": "Bonded"
+}
+            ],
+            "last_total_power": "0",
+            "exported": false,
+            "last_validator_powers": [],
+            "delegations": [],
+            "unbonding_delegations": [],
+            "redelegations": []
+        }"#;
 
-            addr_set.insert(cons_pub_key_raw);
-        }
-        Ok(())
+        assert_eq!(
+            serde_json::from_str::<GenesisState>(genesis)
+                .unwrap_err()
+                .to_string(),
+            "unbonding time must be non negative: -1 at line 8 column 13".to_string()
+        );
     }
 }

--- a/x/staking/src/keeper/bonded.rs
+++ b/x/staking/src/keeper/bonded.rs
@@ -20,7 +20,7 @@ impl<
         // original routine is infallible, it means that the amount should be a valid number.
         // All errors in sdk panics in this method
         let coins = SendCoins::new(vec![Coin {
-            denom: params.bond_denom,
+            denom: params.bond_denom().clone(),
             amount,
         }])
         .unwrap();

--- a/x/staking/src/keeper/delegation.rs
+++ b/x/staking/src/keeper/delegation.rs
@@ -63,7 +63,11 @@ impl<
                 BondStatus::Unbonded | BondStatus::Unbonding => &self.not_bonded_module,
             };
 
-            let denom = self.staking_params_keeper.try_get(ctx)?.bond_denom;
+            let denom = self
+                .staking_params_keeper
+                .try_get(ctx)?
+                .bond_denom()
+                .clone();
             let coins = SendCoins::new(vec![Coin {
                 denom,
                 amount: bond_amount,

--- a/x/staking/src/keeper/gov.rs
+++ b/x/staking/src/keeper/gov.rs
@@ -22,7 +22,7 @@ impl<
     ) -> Result<impl Iterator<Item = Result<Validator, GasStoreErrors>>, GasStoreErrors> {
         Ok(BoundedValidatorsIterator::new(
             ctx.kv_store(&self.store_key),
-            self.staking_params_keeper.try_get(ctx)?.max_validators,
+            self.staking_params_keeper.try_get(ctx)?.max_validators(),
         ))
     }
 
@@ -47,7 +47,7 @@ impl<
         self.bank_keeper.balance(
             ctx,
             account.get_address(),
-            &self.staking_params_keeper.try_get(ctx)?.bond_denom,
+            &self.staking_params_keeper.try_get(ctx)?.bond_denom(),
         )
     }
 }

--- a/x/staking/src/keeper/historical_info.rs
+++ b/x/staking/src/keeper/historical_info.rs
@@ -13,7 +13,7 @@ impl<
 {
     pub fn track_historical_info<DB: Database>(&self, ctx: &mut BlockContext<'_, DB, SK>) {
         let params = self.staking_params_keeper.get(ctx);
-        let entry_num = params.historical_entries;
+        let entry_num = params.historical_entries();
 
         // Prune store to ensure we only have parameter-defined historical entries.
         // In most cases, this will involve removing a single historical entry.

--- a/x/staking/src/keeper/mod.rs
+++ b/x/staking/src/keeper/mod.rs
@@ -188,7 +188,7 @@ impl<
 
         let bonded_coins = if !bonded_tokens.is_zero() {
             vec![Coin {
-                denom: genesis.params.bond_denom.clone(),
+                denom: genesis.params.bond_denom().clone(),
                 amount: bonded_tokens,
             }]
         } else {
@@ -196,7 +196,7 @@ impl<
         };
         let not_bonded_coins = if !not_bonded_tokens.is_zero() {
             vec![Coin {
-                denom: genesis.params.bond_denom,
+                denom: genesis.params.bond_denom().clone(),
                 amount: not_bonded_tokens,
             }]
         } else {
@@ -397,7 +397,7 @@ impl<
         ctx: &mut CTX,
     ) -> anyhow::Result<Vec<ValidatorUpdate>> {
         let params = self.staking_params_keeper.get(ctx);
-        let max_validators = params.max_validators;
+        let max_validators = params.max_validators();
         let power_reduction = self.power_reduction(ctx);
         let mut total_power = 0;
         let mut amt_from_bonded_to_not_bonded = Uint256::zero();
@@ -528,7 +528,7 @@ impl<
         // All errors in sdk panics in this method
         let params = self.staking_params_keeper.try_get(ctx)?;
         let coins = SendCoins::new(vec![Coin {
-            denom: params.bond_denom,
+            denom: params.bond_denom().clone(),
             amount,
         }])
         .unwrap();
@@ -564,7 +564,7 @@ impl<
             BondStatus::Bonded => {
                 // the longest wait - just unbonding period from now
                 let params = self.staking_params_keeper.try_get(ctx)?;
-                let duration = chrono::TimeDelta::nanoseconds(params.unbonding_time);
+                let duration = chrono::TimeDelta::nanoseconds(params.unbonding_time());
                 let time = ctx.get_time();
                 // TODO: consider to work with time in Gears
                 let time =

--- a/x/staking/src/keeper/query.rs
+++ b/x/staking/src/keeper/query.rs
@@ -59,7 +59,7 @@ impl<
             .tokens_from_shares(delegation.shares)
             .map_err(|e| AppError::Coins(e.to_string()))?;
         let balance = Coin {
-            denom: params.bond_denom,
+            denom: params.bond_denom().clone(),
             amount: tokens.to_uint_floor(),
         };
         Ok(DelegationResponse {

--- a/x/staking/src/keeper/redelegation.rs
+++ b/x/staking/src/keeper/redelegation.rs
@@ -116,7 +116,7 @@ impl<
         let params = self.staking_params_keeper.try_get(ctx)?;
 
         if let Some(redelegation) = self.redelegation(ctx, del_addr, val_src_addr, val_dst_addr)? {
-            Ok(redelegation.entries.len() >= params.max_entries as usize)
+            Ok(redelegation.entries.len() >= params.max_entries() as usize)
         } else {
             Ok(false)
         }
@@ -221,7 +221,7 @@ impl<
 
         let mut balances = vec![];
         let params = self.staking_params_keeper.get(ctx);
-        let denom = params.bond_denom;
+        let denom = params.bond_denom();
         let ctx_time = ctx.header.time.clone();
 
         // loop through all the entries and complete mature redelegation entries

--- a/x/staking/src/keeper/tx.rs
+++ b/x/staking/src/keeper/tx.rs
@@ -36,10 +36,11 @@ impl<
             )));
         }
 
-        if msg.value.denom != params.bond_denom {
+        if &msg.value.denom != params.bond_denom() {
             return Err(AppError::InvalidRequest(format!(
                 "invalid coin denomination: got {}, expected {}",
-                msg.value.denom, params.bond_denom
+                msg.value.denom,
+                params.bond_denom()
             )));
         }
 
@@ -137,10 +138,11 @@ impl<
         let params = self.staking_params_keeper.try_get(ctx)?;
         let delegator_address = msg.delegator_address.clone();
 
-        if msg.amount.denom != params.bond_denom {
+        if &msg.amount.denom != params.bond_denom() {
             return Err(AppError::InvalidRequest(format!(
                 "invalid coin denomination: got {}, expected {}",
-                msg.amount.denom, params.bond_denom
+                msg.amount.denom,
+                params.bond_denom()
             )));
         }
 
@@ -226,10 +228,11 @@ impl<
 
         let params = self.staking_params_keeper.try_get(ctx)?;
 
-        if msg.amount.denom != params.bond_denom {
+        if &msg.amount.denom != params.bond_denom() {
             return Err(AppError::InvalidRequest(format!(
                 "invalid coin denomination: got {}, expected {}",
-                msg.amount.denom, params.bond_denom
+                msg.amount.denom,
+                params.bond_denom()
             )));
         }
 

--- a/x/staking/src/keeper/unbonding.rs
+++ b/x/staking/src/keeper/unbonding.rs
@@ -296,7 +296,7 @@ impl<
         } else {
             return Err(AppError::Custom("No unbonding delegation".into()).into());
         };
-        let bond_denom = params.bond_denom;
+        let bond_denom = params.bond_denom();
         let mut balances = vec![];
         let ctx_time = ctx.get_time();
 

--- a/x/staking/src/keeper/validators_and_total_power.rs
+++ b/x/staking/src/keeper/validators_and_total_power.rs
@@ -130,7 +130,7 @@ impl<
         let validators_store = store.prefix_store(LAST_VALIDATOR_POWER_KEY);
 
         // add the actual validator power sorted store
-        let max_validators = self.staking_params_keeper.try_get(ctx)?.max_validators as usize;
+        let max_validators = self.staking_params_keeper.try_get(ctx)?.max_validators() as usize;
         let mut validators = Vec::with_capacity(max_validators);
         for (i, next) in validators_store.into_range(..).enumerate() {
             let (_k, v) = next?;

--- a/x/staking/src/types/query.rs
+++ b/x/staking/src/types/query.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use gears::{
     core::{errors::CoreError, Protobuf},
-    error::IBC_ENCODE_UNWRAP,
+    error::{AppError, IBC_ENCODE_UNWRAP},
     tendermint::types::proto::Protobuf as TendermintProtobuf,
     types::{
         address::{AccAddress, ValAddress},
@@ -441,16 +441,18 @@ pub struct QueryParamsResponse {
 }
 
 impl TryFrom<QueryParamsResponseRaw> for QueryParamsResponse {
-    type Error = gears::types::errors::Error;
+    type Error = AppError;
 
     fn try_from(raw: QueryParamsResponseRaw) -> Result<Self, Self::Error> {
-        let params = Params {
-            unbonding_time: raw.unbonding_time,
-            max_validators: raw.max_validators,
-            max_entries: raw.max_entries,
-            historical_entries: raw.historical_entries,
-            bond_denom: raw.bond_denom.try_into()?,
-        };
+        let params = Params::new(
+            raw.unbonding_time,
+            raw.max_validators,
+            raw.max_entries,
+            raw.historical_entries,
+            raw.bond_denom
+                .try_into()
+                .map_err(|e: gears::types::errors::Error| AppError::Custom(e.to_string()))?,
+        )?;
         Ok(QueryParamsResponse { params })
     }
 }
@@ -472,11 +474,11 @@ pub struct QueryParamsResponseRaw {
 impl From<QueryParamsResponse> for QueryParamsResponseRaw {
     fn from(query: QueryParamsResponse) -> Self {
         Self {
-            unbonding_time: query.params.unbonding_time,
-            max_validators: query.params.max_validators,
-            max_entries: query.params.max_entries,
-            historical_entries: query.params.historical_entries,
-            bond_denom: query.params.bond_denom.to_string(),
+            unbonding_time: query.params.unbonding_time(),
+            max_validators: query.params.max_validators(),
+            max_entries: query.params.max_entries(),
+            historical_entries: query.params.historical_entries(),
+            bond_denom: query.params.bond_denom().to_string(),
         }
     }
 }


### PR DESCRIPTION
This removes the need to call validate on the genesis struct during init_genesis, which removes the need to panic.