### PR TITLE
Fix broken auth integration test

### DIFF
--- a/gaia-rs/tests/auth.rs
+++ b/gaia-rs/tests/auth.rs
@@ -45,7 +45,7 @@ fn account_query() -> anyhow::Result<()> {
         account: Some(Account::Base(BaseAccount {
             address: acc_adress,
             pub_key: None,
-            account_number: 0,
+            account_number: 2,
             sequence: 0,
         })),
     }));


### PR DESCRIPTION
The introduction of the staking module broke this test. The staking init method creates two module accounts which bumps the account number of the account created in this test from zero to two.