### PR TITLE
Add endpoint use HttpClientUrl

### DIFF
--- a/gears/src/commands/node/run.rs
+++ b/gears/src/commands/node/run.rs
@@ -37,6 +37,8 @@ pub enum RunError {
     TendermintServer(#[from] tendermint::abci::errors::Error),
     #[error("{0}")]
     Custom(String),
+    #[error("{0}")]
+    TendermintRPC(#[from] tendermint::rpc::error::Error),
 }
 
 #[derive(Debug, Clone, Default, strum::Display)]
@@ -132,7 +134,7 @@ pub fn run<
         app.clone(),
         rest_listen_addr,
         router_builder.build_router::<BaseApp<DB, PSK, H, AI>>(),
-        config.tendermint_rpc_address,
+        config.tendermint_rpc_address.try_into()?,
     );
 
     run_grpc_server(router_builder.build_grpc_router::<BaseApp<DB, PSK, H, AI>>(app.clone()));

--- a/gears/src/config.rs
+++ b/gears/src/config.rs
@@ -41,7 +41,7 @@ impl<T: DeserializeOwned + Serialize + Default + Clone> ApplicationConfig for T 
 #[serde(deny_unknown_fields)]
 #[serde(default)]
 pub struct Config<AC: Default + Clone> {
-    pub tendermint_rpc_address: Url,
+    pub tendermint_rpc_address: Url, // TODO: change to HttpClientUrl when Serialize and Deserialize are implemented
     pub rest_listen_addr: SocketAddr,
     pub address: SocketAddr,
     pub min_gas_prices: Option<MinGasPrices>,

--- a/tendermint/src/informal/mod.rs
+++ b/tendermint/src/informal/mod.rs
@@ -1,4 +1,5 @@
 pub mod genesis;
 pub mod node;
 
+pub use tendermint_informal::Block;
 pub use tendermint_informal::Hash;

--- a/tendermint/src/rpc/client.rs
+++ b/tendermint/src/rpc/client.rs
@@ -1,2 +1,3 @@
 pub use tendermint_rpc::Client;
 pub use tendermint_rpc::HttpClient;
+pub use tendermint_rpc::HttpClientUrl;

--- a/tendermint/src/rpc/endpoint.rs
+++ b/tendermint/src/rpc/endpoint.rs
@@ -1,0 +1,1 @@
+pub use tendermint_rpc::endpoint::block::Response;

--- a/tendermint/src/rpc/mod.rs
+++ b/tendermint/src/rpc/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod endpoint;
 pub mod error;
 pub mod query;
 pub mod response;


### PR DESCRIPTION
Use HttpClientUrl instead of Url as close to parsing as possible to avaid failing later. We can parse directly to a HttpClientUrl once serde is implemented on that type.