### PR TITLE
feat: add method `begin_block` to `evidence`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,8 +1660,8 @@ dependencies = [
  "prost 0.11.9",
  "serde",
  "serde_json",
- "strum",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/gears/src/baseapp/abci.rs
+++ b/gears/src/baseapp/abci.rs
@@ -245,21 +245,17 @@ impl<DB: Database, PSK: ParamsSubspaceKey, H: ABCIHandler, AI: ApplicationInfo>
 
         let mut state = self.state.write().expect(POISONED_LOCK);
 
-        let consensus_params = {
-            let ctx = state.simple_ctx(request.header.height);
+        let ctx = state.simple_ctx(request.header.height);
 
-            let max_gas = self
-                .baseapp_params_keeper
-                .block_params(&ctx)
-                .map(|e| e.max_gas)
-                .unwrap_or_default(); // This is how cosmos handles it https://github.com/cosmos/cosmos-sdk/blob/d3f09c222243bb3da3464969f0366330dcb977a8/baseapp/baseapp.go#L497
+        let max_gas = self
+            .baseapp_params_keeper
+            .block_params(&ctx)
+            .map(|e| e.max_gas)
+            .unwrap_or_default(); // This is how cosmos handles it https://github.com/cosmos/cosmos-sdk/blob/d3f09c222243bb3da3464969f0366330dcb977a8/baseapp/baseapp.go#L497
 
-            let params = self.baseapp_params_keeper.consensus_params(&ctx);
+        let consensus_params = self.baseapp_params_keeper.consensus_params(&ctx);
 
-            state.replace_meter(Gas::from(max_gas));
-
-            params
-        };
+        state.replace_meter(Gas::from(max_gas));
 
         let mut ctx = state.block_ctx(request.header.clone(), consensus_params);
 

--- a/gears/src/baseapp/abci.rs
+++ b/gears/src/baseapp/abci.rs
@@ -63,8 +63,9 @@ impl<DB: Database, PSK: ParamsSubspaceKey, H: ABCIHandler, AI: ApplicationInfo>
 
         let mut ctx = state.init_ctx(initial_height, time, chain_id);
 
+        // TODO: do we care about error in the consensus params?
         self.baseapp_params_keeper
-            .set_consensus_params(&mut ctx, consensus_params.clone().into());
+            .set_consensus_params(&mut ctx, consensus_params.clone().try_into().unwrap());
 
         let val_updates = self
             .abci_handler
@@ -244,19 +245,23 @@ impl<DB: Database, PSK: ParamsSubspaceKey, H: ABCIHandler, AI: ApplicationInfo>
 
         let mut state = self.state.write().expect(POISONED_LOCK);
 
-        {
-            let mut ctx = state.simple_ctx(request.header.height);
+        let consensus_params = {
+            let ctx = state.simple_ctx(request.header.height);
 
             let max_gas = self
                 .baseapp_params_keeper
-                .block_params(&mut ctx)
+                .block_params(&ctx)
                 .map(|e| e.max_gas)
                 .unwrap_or_default(); // This is how cosmos handles it https://github.com/cosmos/cosmos-sdk/blob/d3f09c222243bb3da3464969f0366330dcb977a8/baseapp/baseapp.go#L497
 
-            state.replace_meter(Gas::from(max_gas))
-        }
+            let params = self.baseapp_params_keeper.consensus_params(&ctx);
 
-        let mut ctx = state.block_ctx(request.header.clone());
+            state.replace_meter(Gas::from(max_gas));
+
+            params
+        };
+
+        let mut ctx = state.block_ctx(request.header.clone(), consensus_params);
 
         self.abci_handler.begin_block(&mut ctx, request);
 
@@ -276,7 +281,12 @@ impl<DB: Database, PSK: ParamsSubspaceKey, H: ABCIHandler, AI: ApplicationInfo>
             .get_block_header()
             .expect("block header is set in begin block");
 
-        let mut ctx = state.block_ctx(header);
+        let consensus_params = {
+            self.baseapp_params_keeper
+                .consensus_params(&state.simple_ctx(header.height))
+        };
+
+        let mut ctx = state.block_ctx(header, consensus_params);
 
         let validator_updates = self.abci_handler.end_block(&mut ctx, request);
 

--- a/gears/src/baseapp/abci.rs
+++ b/gears/src/baseapp/abci.rs
@@ -63,9 +63,8 @@ impl<DB: Database, PSK: ParamsSubspaceKey, H: ABCIHandler, AI: ApplicationInfo>
 
         let mut ctx = state.init_ctx(initial_height, time, chain_id);
 
-        // TODO: do we care about error in the consensus params?
         self.baseapp_params_keeper
-            .set_consensus_params(&mut ctx, consensus_params.clone().try_into().unwrap());
+            .set_consensus_params(&mut ctx, consensus_params.clone().into());
 
         let val_updates = self
             .abci_handler

--- a/gears/src/baseapp/params.rs
+++ b/gears/src/baseapp/params.rs
@@ -1,4 +1,3 @@
-use core_types::errors::CoreError;
 use database::Database;
 use kv_store::StoreKey;
 use serde::{Deserialize, Serialize};
@@ -52,22 +51,20 @@ pub struct ConsensusParams {
     // pub version: Option<VersionParams>
 }
 
-impl TryFrom<inner::ConsensusParams> for ConsensusParams {
-    type Error = CoreError;
-
-    fn try_from(
+impl From<inner::ConsensusParams> for ConsensusParams {
+    fn from(
         inner::ConsensusParams {
             block,
             evidence,
             validator,
             version: _,
         }: inner::ConsensusParams,
-    ) -> Result<Self, Self::Error> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             block: block.into(),
-            evidence: evidence.try_into()?,
+            evidence: evidence.into(),
             validator: validator.into(),
-        })
+        }
     }
 }
 
@@ -164,7 +161,7 @@ pub struct EvidenceParams {
     pub max_age_num_blocks: i64,
     #[serde(serialize_with = "serialize_duration_opt_to_nanos_string")]
     #[serde(deserialize_with = "deserialize_duration_opt_from_nanos_string")]
-    pub max_age_duration: Duration,
+    pub max_age_duration: Option<Duration>,
     #[serde_as(as = "serde_with::DisplayFromStr")]
     pub max_bytes: i64,
 }
@@ -175,23 +172,19 @@ impl Default for EvidenceParams {
         // from sdk testing setup
         EvidenceParams {
             max_age_num_blocks: 302400,
-            max_age_duration: Duration::new_from_secs(3 * 7 * 24 * 3600), // 3 weeks
+            max_age_duration: Some(Duration::new_from_secs(3 * 7 * 24 * 3600)), // 3 weeks
             max_bytes: 10000,
         }
     }
 }
 
-impl TryFrom<inner::EvidenceParams> for EvidenceParams {
-    type Error = CoreError;
-
-    fn try_from(params: inner::EvidenceParams) -> Result<Self, Self::Error> {
-        Ok(EvidenceParams {
+impl From<inner::EvidenceParams> for EvidenceParams {
+    fn from(params: inner::EvidenceParams) -> EvidenceParams {
+        EvidenceParams {
             max_age_num_blocks: params.max_age_num_blocks,
-            max_age_duration: params.max_age_duration.ok_or(CoreError::MissingField(
-                "field max_age_duration is missed".to_string(),
-            ))?,
+            max_age_duration: params.max_age_duration,
             max_bytes: params.max_bytes,
-        })
+        }
     }
 }
 

--- a/gears/src/baseapp/state.rs
+++ b/gears/src/baseapp/state.rs
@@ -13,7 +13,10 @@ use crate::{
     types::gas::{basic_meter::BasicGasMeter, infinite_meter::InfiniteGasMeter, Gas, GasMeter},
 };
 
-use super::mode::{check::CheckTxMode, deliver::DeliverTxMode};
+use super::{
+    mode::{check::CheckTxMode, deliver::DeliverTxMode},
+    ConsensusParams,
+};
 
 #[derive(Debug)]
 pub struct ApplicationState<DB, AH: ABCIHandler> {
@@ -93,7 +96,16 @@ impl<DB: Database, AH: ABCIHandler> ApplicationState<DB, AH> {
         SimpleContext::new(SimpleBackend::Application(&mut self.multi_store), height)
     }
 
-    pub fn block_ctx(&mut self, header: Header) -> BlockContext<'_, DB, AH::StoreKey> {
-        BlockContext::new(&mut self.multi_store, header.height, header.clone())
+    pub fn block_ctx(
+        &mut self,
+        header: Header,
+        consensus_params: ConsensusParams,
+    ) -> BlockContext<'_, DB, AH::StoreKey> {
+        BlockContext::new(
+            &mut self.multi_store,
+            header.height,
+            header.clone(),
+            consensus_params,
+        )
     }
 }

--- a/gears/src/context/block.rs
+++ b/gears/src/context/block.rs
@@ -5,7 +5,10 @@ use kv_store::{
     StoreKey,
 };
 
-use crate::types::store::kv::{mutable::StoreMut, Store};
+use crate::{
+    baseapp::ConsensusParams,
+    types::store::kv::{mutable::StoreMut, Store},
+};
 use tendermint::types::{
     chain_id::ChainId,
     proto::{event::Event, header::Header},
@@ -19,6 +22,7 @@ pub struct BlockContext<'a, DB, SK> {
     multi_store: &'a mut ApplicationMultiBank<DB, SK>,
     pub(crate) height: u32,
     pub header: Header,
+    pub(crate) consensus_params: ConsensusParams,
     pub events: Vec<Event>,
 }
 
@@ -27,17 +31,23 @@ impl<'a, DB, SK> BlockContext<'a, DB, SK> {
         multi_store: &'a mut ApplicationMultiBank<DB, SK>,
         height: u32,
         header: Header,
+        consensus_params: ConsensusParams,
     ) -> Self {
         BlockContext {
             multi_store,
             height,
             events: Vec::new(),
+            consensus_params,
             header,
         }
     }
 
     pub fn chain_id(&self) -> &ChainId {
         &self.header.chain_id
+    }
+
+    pub fn consensus_params(&self) -> &ConsensusParams {
+        &self.consensus_params
     }
 }
 

--- a/gears/src/error.rs
+++ b/gears/src/error.rs
@@ -1,6 +1,7 @@
 use address::AddressError;
 use core_types::errors::CoreError;
 use cosmwasm_std::Decimal256RangeExceeded;
+use tendermint::error::Error as TendermintError;
 
 use crate::types::{base::errors::CoinError, errors::DenomError, tx::metadata::MetadataParseError};
 
@@ -45,6 +46,8 @@ pub enum ProtobufError {
     Denom(#[from] DenomError),
     #[error(transparent)]
     Core(#[from] CoreError),
+    #[error("decode adress error: {0}")]
+    Tendermint(#[from] TendermintError),
     #[error("decode adress error: {0}")]
     AddressError(#[from] AddressError),
     #[error("{0}")]

--- a/gears/src/x/keepers/slashing.rs
+++ b/gears/src/x/keepers/slashing.rs
@@ -1,15 +1,60 @@
-use crate::x::module::Module;
+use crate::{
+    context::{QueryableContext, TransactionalContext},
+    types::store::gas::errors::GasStoreErrors,
+    x::module::Module,
+};
+use address::ConsAddress;
+use cosmwasm_std::Decimal256;
+use database::Database;
 use kv_store::StoreKey;
+use tendermint::types::{proto::crypto::PublicKey, time::timestamp::Timestamp};
 
 /// EvidenceSlashingKeeper defines the slashing module interface contract needed by the
 /// evidence module.
 pub trait EvidenceSlashingKeeper<SK: StoreKey, M: Module>: Clone + Send + Sync + 'static {
-    // GetPubkey(sdk.Context, cryptotypes.Address) (cryptotypes.PubKey, error)
-    // IsTombstoned(sdk.Context, sdk.ConsAddress) bool
-    // HasValidatorSigningInfo(sdk.Context, sdk.ConsAddress) bool
-    // Tombstone(sdk.Context, sdk.ConsAddress)
-    // Slash(sdk.Context, sdk.ConsAddress, sdk.Dec, int64, int64)
-    // SlashFractionDoubleSign(sdk.Context) sdk.Dec
-    // Jail(sdk.Context, sdk.ConsAddress)
-    // JailUntil(sdk.Context, sdk.ConsAddress, time.Time)
+    /// get a particular validator by operator address
+    fn pubkey<DB: Database, CTX: QueryableContext<DB, SK>>(
+        &self,
+        ctx: &CTX,
+        addr: &ConsAddress,
+    ) -> Result<Option<PublicKey>, GasStoreErrors>;
+    /// get a particular validator by operator address
+    fn has_validator_signing_info<DB: Database, CTX: QueryableContext<DB, SK>>(
+        &self,
+        ctx: &CTX,
+        addr: &ConsAddress,
+    ) -> Result<bool, GasStoreErrors>;
+    fn is_tombstoned<DB: Database, CTX: QueryableContext<DB, SK>>(
+        &self,
+        ctx: &CTX,
+        addr: &ConsAddress,
+    ) -> Result<bool, GasStoreErrors>;
+    fn slash_fraction_double_sign<DB: Database, CTX: TransactionalContext<DB, SK>>(
+        &self,
+        ctx: &CTX,
+    ) -> Result<Decimal256, GasStoreErrors>;
+    fn slash<DB: Database, CTX: TransactionalContext<DB, SK>>(
+        &self,
+        ctx: &CTX,
+        addr: &ConsAddress,
+        amount: Decimal256,
+        validator_power: i64,
+        height: i64,
+    ) -> Result<(), GasStoreErrors>;
+    fn jail<DB: Database, CTX: TransactionalContext<DB, SK>>(
+        &self,
+        ctx: &CTX,
+        addr: &ConsAddress,
+    ) -> Result<(), GasStoreErrors>;
+    fn jail_until<DB: Database, CTX: TransactionalContext<DB, SK>>(
+        &self,
+        ctx: &CTX,
+        addr: &ConsAddress,
+        time: Timestamp,
+    ) -> Result<(), GasStoreErrors>;
+    fn tombstone<DB: Database, CTX: TransactionalContext<DB, SK>>(
+        &self,
+        ctx: &CTX,
+        addr: &ConsAddress,
+    ) -> Result<(), GasStoreErrors>;
 }

--- a/gears/src/x/types/validator.rs
+++ b/gears/src/x/types/validator.rs
@@ -1,9 +1,8 @@
+use crate::{error::NumericError, types::address::ValAddress};
 use cosmwasm_std::{Decimal256, Uint256};
 use prost::Enumeration;
 use serde::{Deserialize, Serialize};
 use tendermint::types::proto::crypto::PublicKey;
-
-use crate::{error::NumericError, types::address::ValAddress};
 
 pub trait StakingValidator {
     fn operator(&self) -> &ValAddress;
@@ -14,10 +13,11 @@ pub trait StakingValidator {
     fn is_jailed(&self) -> bool;
     fn min_self_delegation(&self) -> Uint256;
     fn commission(&self) -> Decimal256;
+    fn status(&self) -> BondStatus;
     fn tokens_from_shares(&self, shares: Decimal256) -> Result<Decimal256, NumericError>;
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Enumeration, strum::Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Enumeration, strum::Display)]
 pub enum BondStatus {
     #[serde(rename = "BOND_STATUS_UNBONDED")]
     #[strum(to_string = "Unbonded")]

--- a/tendermint/src/informal/mod.rs
+++ b/tendermint/src/informal/mod.rs
@@ -3,3 +3,6 @@ pub mod node;
 
 pub use tendermint_informal::Block;
 pub use tendermint_informal::Hash;
+pub mod hash {
+    pub use tendermint_informal::hash::Algorithm;
+}

--- a/tendermint/src/types/proto/info.rs
+++ b/tendermint/src/types/proto/info.rs
@@ -89,7 +89,7 @@ pub struct Evidence {
 }
 
 impl Evidence {
-    pub fn r#type(&self) -> EvidenceType {
+    pub fn kind(&self) -> EvidenceType {
         EvidenceType::from_i32(self.r#type).unwrap_or(EvidenceType::Unknown)
     }
 }

--- a/tendermint/src/types/time/timestamp.rs
+++ b/tendermint/src/types/time/timestamp.rs
@@ -238,10 +238,10 @@ impl Timestamp {
     }
 
     /// Creates a new `Timestamp` from the given seconds and nanoseconds.
-    pub fn new(seconds: TimestampSeconds, nanos: Nanoseconds) -> Self {
+    pub const fn new(seconds: TimestampSeconds, nanos: Nanoseconds) -> Self {
         Self {
-            seconds: seconds.into(),
-            nanos: nanos.into(),
+            seconds: seconds.0,
+            nanos: nanos.0 as i32,
         }
     }
 

--- a/x/evidence/Cargo.toml
+++ b/x/evidence/Cargo.toml
@@ -12,6 +12,4 @@ prost = { workspace = true }
 serde = { workspace = true, default-features = false }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-
-[dev-dependencies]
-strum = { workspace = true }
+tracing = { workspace = true }

--- a/x/evidence/src/errors.rs
+++ b/x/evidence/src/errors.rs
@@ -1,4 +1,4 @@
-use gears::tendermint::informal::Hash;
+use gears::{tendermint::informal::Hash, types::address::ConsAddress};
 
 #[derive(Debug, thiserror::Error)]
 pub enum GenesisStateError {
@@ -12,4 +12,10 @@ pub enum GenesisStateError {
 pub enum EvidenceError {
     #[error("Evidence with hash {0} already exists")]
     AlreadyExists(Hash),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EquivocationEvidenceError {
+    #[error("expected signing info for validator {0} but not found")]
+    SigningInfoNotExists(ConsAddress),
 }

--- a/x/evidence/src/keeper/infraction.rs
+++ b/x/evidence/src/keeper/infraction.rs
@@ -1,0 +1,184 @@
+use super::*;
+use crate::{
+    errors::EquivocationEvidenceError,
+    types::{Equivocation, RawEquivocation, DOUBLE_SIGN_JAIL_END_TIME},
+};
+use gears::{
+    context::block::BlockContext,
+    error::{MathOperation, NumericError},
+    x::{
+        keepers::staking::VALIDATOR_UPDATE_DELAY,
+        types::validator::{BondStatus, StakingValidator},
+    },
+};
+
+impl<
+        SK: StoreKey,
+        StkK: SlashingStakingKeeper<SK, M>,
+        SlsK: EvidenceSlashingKeeper<SK, M>,
+        E: Evidence + Default,
+        M: Module,
+    > Keeper<SK, StkK, SlsK, E, M>
+where
+    <E as std::convert::TryFrom<Any>>::Error: std::fmt::Debug,
+{
+    /// HandleEquivocationEvidence implements an equivocation evidence handler. Assuming the
+    /// evidence is valid, the validator committing the misbehavior will be slashed,
+    /// jailed and tombstoned. Once tombstoned, the validator will not be able to
+    /// recover. Note, the evidence contains the block time and height at the time of
+    /// the equivocation.
+    ///
+    /// The evidence is considered invalid if:
+    /// - the evidence is too old
+    /// - the validator is unbonded or does not exist
+    /// - the signing info does not exist (will panic)
+    /// - is already tombstoned
+
+    // TODO: Some of the invalid constraints listed above may need to be reconsidered
+    // in the case of a lunatic attack.
+    pub fn handle_equivocation_evidence<DB: Database>(
+        &self,
+        ctx: &mut BlockContext<DB, SK>,
+        evidence: &Equivocation,
+        // TODO: error type
+    ) -> anyhow::Result<()> {
+        let cons_address = evidence.consensus_address.clone();
+        if self
+            .slashing_keeper
+            .pubkey(ctx, &cons_address)
+            .unwrap_gas()
+            .is_none()
+        {
+            // Ignore evidence that cannot be handled.
+            //
+            // NOTE: We used to panic with:
+            // `panic!(format!("Validator consensus-address {} not found", cons_address))`,
+            // but this couples the expectations of the app to both Tendermint.  Both are
+            // expected to provide the full range of allowable but none of the disallowed
+            // evidence types.  Instead of getting this coordination right, it is easier to
+            // relax the constraints and ignore evidence that cannot be handled.
+            return Ok(());
+        }
+
+        // calculate the age of the evidence
+        let infraction_height = evidence.height;
+        let infraction_time = evidence.time;
+        let age_duration = ctx
+            .get_time()
+            .checked_sub(&infraction_time)
+            .ok_or(NumericError::Overflow(MathOperation::Sub))?;
+        let age_blocks = ctx
+            .height()
+            .checked_sub(infraction_height.try_into()?)
+            .ok_or(NumericError::Overflow(MathOperation::Sub))?;
+
+        // Reject evidence if the double-sign is too old. Evidence is considered stale
+        // if the difference in time and number of blocks is greater than the allowed
+        // parameters defined.
+        let cons_params = ctx.consensus_params();
+
+        if age_duration > cons_params.evidence.max_age_duration
+            && age_blocks > cons_params.evidence.max_age_num_blocks.try_into()?
+        {
+            tracing::info!(
+                name: "ignored equivocation; evidence too old",
+                target: "module::evidence",
+                validator = cons_address.to_string(),
+                ?infraction_height,
+                max_age_num_blocks = cons_params.evidence.max_age_num_blocks,
+                infraction_time = infraction_time.format_string_rounded(),
+                // TODO: what is better option to show duration?
+                max_age_duration = i128::from(cons_params.evidence.max_age_duration.duration_nanoseconds()),
+            );
+            return Ok(());
+        }
+
+        let validator = if let Some(validator) = self
+            .staking_keeper
+            .validator_by_cons_addr(ctx, &cons_address)
+            .unwrap_gas()
+        {
+            if validator.status() == BondStatus::Unbonded {
+                // Defensive: Simulation doesn't take unbonding periods into account, and
+                // Tendermint might break this assumption at some point.
+                return Ok(());
+            }
+            validator
+        } else {
+            return Ok(());
+        };
+
+        if !self
+            .slashing_keeper
+            .has_validator_signing_info(ctx, &cons_address)
+            .unwrap_gas()
+        {
+            return Err(EquivocationEvidenceError::SigningInfoNotExists(cons_address).into());
+        }
+
+        // ignore if the validator is already tombstoned
+        if self
+            .slashing_keeper
+            .is_tombstoned(ctx, &cons_address)
+            .unwrap_gas()
+        {
+            tracing::info!(
+                name: "ignored equivocation; validator already tombstoned",
+                target: "module::evidence",
+                validator = cons_address.to_string(),
+                ?infraction_height,
+                infraction_time = infraction_time.format_string_rounded(),
+            );
+            return Ok(());
+        }
+        tracing::info!(
+            name: "confirmed equivocation",
+            target: "module::evidence",
+            validator = cons_address.to_string(),
+            ?infraction_height,
+            infraction_time = infraction_time.format_string_rounded(),
+        );
+        // We need to retrieve the stake distribution which signed the block, so we
+        // subtract ValidatorUpdateDelay from the evidence height.
+        // Note, that this *can* result in a negative "distributionHeight", up to
+        // -ValidatorUpdateDelay, i.e. at the end of the
+        // pre-genesis block (none) = at the beginning of the genesis block.
+        // That's fine since this is just used to filter unbonding delegations & redelegations.
+        let distribution_height = infraction_height
+            .checked_sub(VALIDATOR_UPDATE_DELAY.try_into()?)
+            .ok_or(NumericError::Overflow(MathOperation::Sub))?;
+
+        // Slash validator. The `power` is the int64 power of the validator as provided
+        // to/by Tendermint. This value is validator.Tokens as sent to Tendermint via
+        // ABCI, and now received as evidence. The fraction is passed in to separately
+        // to slash unbonding and rebonding delegations.
+        self.slashing_keeper
+            .slash(
+                ctx,
+                &cons_address,
+                self.slashing_keeper
+                    .slash_fraction_double_sign(ctx)
+                    .unwrap_gas(),
+                evidence.power.into(),
+                distribution_height,
+            )
+            .unwrap_gas();
+
+        // Jail the validator if not already jailed. This will begin unbonding the
+        // validator if not already unbonding (tombstoned).
+        if !validator.is_jailed() {
+            self.slashing_keeper.jail(ctx, &cons_address).unwrap_gas();
+        }
+
+        self.slashing_keeper
+            .jail_until(ctx, &cons_address, DOUBLE_SIGN_JAIL_END_TIME)
+            .unwrap_gas();
+        self.slashing_keeper
+            .tombstone(ctx, &cons_address)
+            .unwrap_gas();
+        self.set_evidence(ctx, &RawEquivocation::from(evidence.clone()))
+            .unwrap_gas();
+
+        Ok(())
+    }
+}

--- a/x/evidence/src/types/mod.rs
+++ b/x/evidence/src/types/mod.rs
@@ -1,13 +1,27 @@
 use gears::{
     context::TransactionalContext,
-    core::any::google::Any,
+    core::{any::google::Any, errors::CoreError},
+    derive::Protobuf,
     store::{database::Database, StoreKey},
-    tendermint::informal::Hash,
+    tendermint::{
+        informal::{hash::Algorithm, Hash},
+        types::{
+            proto::{info::Evidence as TmEvidence, validator::VotingPower},
+            time::timestamp::{Nanoseconds, Timestamp, TimestampSeconds},
+        },
+    },
+    types::address::ConsAddress,
 };
 use prost::Message;
+use serde::{Deserialize, Serialize};
 
 mod query;
 mod tx;
+
+// DoubleSignJailEndTime period ends at Max Time supported by Amino
+// (Dec 31, 9999 - 23:59:59 GMT).
+pub(crate) const DOUBLE_SIGN_JAIL_END_TIME: Timestamp =
+    Timestamp::new(TimestampSeconds::MAX, Nanoseconds::MIN);
 
 //
 
@@ -25,4 +39,92 @@ pub trait Evidence: Message + TryFrom<Any> {
         ctx: &mut CTX,
         evidence: &Self,
     ) -> Result<(), <Self as Evidence>::Error>;
+}
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, Message)]
+pub struct RawEquivocation {
+    #[prost(int64, tag = "1")]
+    pub height: i64,
+    #[prost(message, optional, tag = "2")]
+    pub time: Option<Timestamp>,
+    #[prost(uint64, tag = "3")]
+    pub power: u64,
+    #[prost(string, tag = "4")]
+    pub consensus_address: String,
+}
+
+/// Equivocation implements the Evidence interface and defines evidence of double
+/// signing misbehavior.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Protobuf)]
+#[proto(raw = "RawEquivocation")]
+pub struct Equivocation {
+    pub height: i64,
+    #[proto(name = "time", optional)]
+    pub time: Timestamp,
+    pub power: VotingPower,
+    pub consensus_address: ConsAddress,
+}
+
+impl From<TmEvidence> for Equivocation {
+    fn from(
+        TmEvidence {
+            r#type: _,
+            validator,
+            height,
+            time,
+            total_voting_power: _,
+        }: TmEvidence,
+    ) -> Self {
+        Self {
+            height,
+            time,
+            power: validator.power,
+            consensus_address: validator.address.into(),
+        }
+    }
+}
+
+impl TryFrom<Any> for RawEquivocation {
+    type Error = CoreError;
+
+    fn try_from(value: Any) -> Result<Self, Self::Error> {
+        match value.type_url.as_str() {
+            // TODO: url?
+            "equivocation" => RawEquivocation::decode::<prost::bytes::Bytes>(value.value.into())
+                .map_err(|e| gears::core::errors::CoreError::DecodeGeneral(e.to_string())),
+            _ => Err(gears::core::errors::CoreError::DecodeGeneral(
+                "message type not recognized".into(),
+            )),
+        }
+    }
+}
+
+impl Evidence for RawEquivocation {
+    type Error = anyhow::Error;
+
+    fn kind(&self) -> String {
+        "equivocation".into()
+    }
+
+    fn string(&self) -> String {
+        // TODO: sdk uses yaml
+        todo!()
+    }
+
+    fn hash(&self) -> Hash {
+        // TODO: check how we can guarantee infallible behavior
+        Hash::from_bytes(Algorithm::Sha256, self.encode_to_vec().as_slice()).unwrap()
+    }
+
+    fn height(&self) -> i64 {
+        self.height
+    }
+
+    fn handle<CTX: TransactionalContext<DB, SK>, DB: Database, SK: StoreKey>(
+        _ctx: &mut CTX,
+        _evidence: &Self,
+    ) -> Result<(), <Self as Evidence>::Error> {
+        // it is handled by module in the `begin_block`
+        unreachable!()
+    }
 }

--- a/x/staking/src/keeper/delegation.rs
+++ b/x/staking/src/keeper/delegation.rs
@@ -125,11 +125,11 @@ impl<
     ) -> Result<Option<Delegation>, GasStoreErrors> {
         let store = QueryableContext::kv_store(ctx, &self.store_key);
         let delegations_store = store.prefix_store(DELEGATION_KEY);
-        let mut key = Vec::from(del_addr.clone());
-        key.extend_from_slice(&Vec::from(val_addr.clone()));
+        let mut key = del_addr.prefix_len_bytes();
+        key.extend_from_slice(&val_addr.prefix_len_bytes());
         Ok(delegations_store
             .get(&key)?
-            .map(|bytes| serde_json::from_slice(&bytes).unwrap_or_corrupt()))
+            .map(|bytes| Delegation::decode_vec(&bytes).unwrap_or_corrupt()))
     }
 
     pub fn set_delegation<DB: Database, CTX: TransactionalContext<DB, SK>>(
@@ -153,8 +153,8 @@ impl<
     ) -> Result<Option<Vec<u8>>, GasStoreErrors> {
         let store = ctx.kv_store_mut(&self.store_key);
         let mut delegations_store = store.prefix_store_mut(DELEGATION_KEY);
-        let mut key = Vec::from(delegation.delegator_address.clone());
-        key.extend_from_slice(&Vec::from(delegation.validator_address.clone()));
+        let mut key = delegation.delegator_address.prefix_len_bytes();
+        key.extend_from_slice(&delegation.validator_address.prefix_len_bytes());
         delegations_store.delete(&key)
     }
 }

--- a/x/staking/src/types/validator.rs
+++ b/x/staking/src/types/validator.rs
@@ -118,6 +118,10 @@ impl StakingValidator for Validator {
         self.commission.commission_rates().rate()
     }
 
+    fn status(&self) -> BondStatus {
+        self.status
+    }
+
     fn tokens_from_shares(&self, shares: Decimal256) -> Result<Decimal256, NumericError> {
         self.tokens_from_shares(shares)
     }


### PR DESCRIPTION
Main features: 
- added method `begin_block`
- updated gears consensus params, changed `Option<Timestamp>` -> `Timestamp` 
- added consensus params to `BlockContext`